### PR TITLE
Typescript Models - Fields instead of properties

### DIFF
--- a/Abstracts/TypescriptModelClassAbstract.cs
+++ b/Abstracts/TypescriptModelClassAbstract.cs
@@ -16,7 +16,7 @@ namespace FuryTech.OdataTypescriptServiceGenerator.Abstracts
                 sourceElement.Descendants()
                     .Where(a => a.Name.LocalName == "Key")
                     .Descendants()
-                    .SingleOrDefault()?
+                    .FirstOrDefault()?  //ToDo: Composite keys
                     .Attribute("Name")?
                     .Value;
             NameSpace = sourceElement.Parent?.Attribute("Namespace")?.Value;

--- a/App.config
+++ b/App.config
@@ -2,14 +2,14 @@
 <configuration>
   <appSettings>
     <!-- Path to the OData Metadata root -->
-    <add key="metadataPath" value="http://dp-local/api/dps/$metadata"/>
+    <add key="metadataPath" value="http://ter-local/api/ter/$metadata"/>
     <add key="endpointName" value="DpsApi"/>
     <!-- A local folder for writing the TS files -->
     <add key="output" value=".\output"/>
     <!-- Purge output if the directory is not empty -->
     <add key="purgeOutput" value="true"/>
     <add key="EntityTypeTemplate" value="Templates\EntityTypeTemplate.tst"/>
-    <add key="EntityPropertyTemplate" value="Templates\PropertyTemplate.tst"/>
+    <add key="EntityPropertyTemplate" value="Templates\FieldTemplate.tst"/>
     <add key="ImportsTemplate" value="Templates\ImportTemplate.tst"/>
     <add key="EnumTypeTemplate" value="Templates\EnumTypeTemplate.tst"/>
     <add key="EnumMemberTemplate" value="Templates\EnumMemberTemplate.tst"/>

--- a/FuryTech.OdataTypescriptServiceGenerator.csproj
+++ b/FuryTech.OdataTypescriptServiceGenerator.csproj
@@ -66,6 +66,9 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TemplateRenderer.cs" />
+    <None Include="Templates\PropertyTemplate.tst">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
@@ -133,7 +136,7 @@
     <None Include="Templates\EnumTypeTemplate.tst">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="Templates\PropertyTemplate.tst">
+    <None Include="Templates\FieldTemplate.tst">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Templates/FieldTemplate.tst
+++ b/Templates/FieldTemplate.tst
@@ -1,0 +1,1 @@
+﻿    public $propertyName$: $propertyType$;

--- a/Templates/PropertyTemplate.tst
+++ b/Templates/PropertyTemplate.tst
@@ -1,1 +1,7 @@
-﻿    public $propertyName$: $propertyType$;
+﻿    private _$propertyName$: $propertyType$;
+    public get $propertyName$(): $propertyType$ {
+        return this._$propertyName$;
+    }
+    public set $propertyName$(value: $propertyType$) {
+        this._$propertyName$ = value;
+    }

--- a/Templates/PropertyTemplate.tst
+++ b/Templates/PropertyTemplate.tst
@@ -1,7 +1,1 @@
-﻿    private _$propertyName$: $propertyType$;
-    public get $propertyName$(): $propertyType$ {
-        return this._$propertyName$;
-    }
-    public set $propertyName$(value: $propertyType$) {
-        this._$propertyName$ = value;
-    }
+﻿    public $propertyName$: $propertyType$;


### PR DESCRIPTION
Changed the TS Model generation behaviour to create fields instead of properties for the easier initialization.